### PR TITLE
add historical to admin join room

### DIFF
--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -947,6 +947,7 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
             content=content,
             require_consent=require_consent,
             outlier=outlier,
+            historical=historical,
         )
 
     async def _should_perform_remote_join(

--- a/synapse/rest/admin/rooms.py
+++ b/synapse/rest/admin/rooms.py
@@ -464,6 +464,10 @@ class JoinRoomAliasServlet(ResolveRoomIdMixin, RestServlet):
         assert_params_in_dict(content, ["user_id"])
         target_user = UserID.from_string(content["user_id"])
 
+        historical = False
+        if "historical" in content:
+            historical = content["historical"]
+
         if not self.is_mine(target_user):
             raise SynapseError(
                 HTTPStatus.BAD_REQUEST,
@@ -503,6 +507,7 @@ class JoinRoomAliasServlet(ResolveRoomIdMixin, RestServlet):
                     action="invite",
                     remote_room_hosts=remote_room_hosts,
                     ratelimit=False,
+                    historical=historical,
                 )
 
         await self.room_member_handler.update_membership(
@@ -510,6 +515,7 @@ class JoinRoomAliasServlet(ResolveRoomIdMixin, RestServlet):
             target=fake_requester.user,
             room_id=room_id,
             action="join",
+            historical=historical,
             remote_room_hosts=remote_room_hosts,
             ratelimit=False,
         )


### PR DESCRIPTION
Purpose of this PR : This PR takes into account the parameter `historical` when the admin add a user into a room (/join).
The `historical` flag allows to set the event that has happened in the past and therefore no notification should be sent for this.

This will help to improve performance and in the notification process `action_for_event_by_user`.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
