### PR TITLE
Canonicaljson dependency fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,9 @@ jsonschema = ">=3.0.0"
 frozendict = ">=1,!=2.1.2"
 # We require 2.1.0 or higher for type hints. Previous guard was >= 1.1.0
 unpaddedbase64 = ">=2.1.0"
-canonicaljson = ">=1.4.0"
+# We require 1.5.0 to work around an issue when running against the C implementation of
+# frozendict: https://github.com/matrix-org/python-canonicaljson/issues/36
+canonicaljson = "^1.5.0"
 # we use the type definitions added in signedjson 1.1.
 signedjson = ">=1.1.0"
 PyNaCl = ">=1.2.1"


### PR DESCRIPTION
Fix from : https://github.com/matrix-org/synapse/pull/13172

When installing synapse it will bring canonicaljson==2.0.0 and raise the following issue

```
Mar 15 17:55:41 tchap-agent1 matrix-synapse_event_creator[4864]:     _check_size_limits(event)
Mar 15 17:55:41 tchap-agent1 matrix-synapse_event_creator[4864]:   File "/opt/synapse/env/lib/python3.7/site-packages/synapse/event_auth.py", line 276, in _check_size_limits
Mar 15 17:55:41 tchap-agent1 matrix-synapse_event_creator[4864]:     if len(encode_canonical_json(event.get_pdu_json())) > MAX_PDU_SIZE:
Mar 15 17:55:41 tchap-agent1 matrix-synapse_event_creator[4864]:   File "/opt/synapse/env/lib/python3.7/site-packages/canonicaljson/__init__.py", line 84, in encode_canonical_json
Mar 15 17:55:41 tchap-agent1 matrix-synapse_event_creator[4864]:     s = _canonical_encoder.encode(data)
Mar 15 17:55:41 tchap-agent1 matrix-synapse_event_creator[4864]:   File "/usr/lib/python3.7/json/encoder.py", line 199, in encode
Mar 15 17:55:41 tchap-agent1 matrix-synapse_event_creator[4864]:     chunks = self.iterencode(o, _one_shot=True)
Mar 15 17:55:41 tchap-agent1 matrix-synapse_event_creator[4864]:   File "/usr/lib/python3.7/json/encoder.py", line 257, in iterencode
Mar 15 17:55:41 tchap-agent1 matrix-synapse_event_creator[4864]:     return _iterencode(o, 0)
Mar 15 17:55:41 tchap-agent1 matrix-synapse_event_creator[4864]:   File "/opt/synapse/env/lib/python3.7/functools.py", line 827, in wrapper
Mar 15 17:55:41 tchap-agent1 matrix-synapse_event_creator[4864]:     return dispatch(args[0].__class__)(*args, **kw)
Mar 15 17:55:41 tchap-agent1 matrix-synapse_event_creator[4864]:   File "/opt/synapse/env/lib/python3.7/site-packages/canonicaljson/__init__.py", line 31, in _preprocess_for_serialisation
Mar 15 17:55:41 tchap-agent1 matrix-synapse_event_creator[4864]:     "Object of type %s is not JSON serializable" % obj.__class__.__name__
Mar 15 17:55:41 tchap-agent1 matrix-synapse_event_creator[4864]: TypeError: Object of type frozendict is not JSON serializable


```


### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
