### PR TITLE
allow the copy of im.vector.room.access_rules event when upgrading room

### DIFF
--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -99,6 +99,7 @@ class EventTypes:
     Redaction: Final = "m.room.redaction"
     ThirdPartyInvite: Final = "m.room.third_party_invite"
     RelatedGroups: Final = "m.room.related_groups"
+    AccessRules: Final = "im.vector.room.access_rules"
 
     RoomHistoryVisibility: Final = "m.room.history_visibility"
     CanonicalAlias: Final = "m.room.canonical_alias"

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -441,6 +441,7 @@ class RoomCreationHandler:
             (EventTypes.ServerACL, ""),
             (EventTypes.RelatedGroups, ""),
             (EventTypes.PowerLevels, ""),
+            (EventTypes.AccessRules, ""),
         ]
 
         # If the old room was a space, copy over the room type and the rooms in


### PR DESCRIPTION
This PR 
- shows how we can make the upgrade of room work for external
- this is only for demonstration otherwise we need to test this properly.


### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
* [ ] [Code style](https://matrix-org.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
